### PR TITLE
Fix: Pydantic warning in chroma store, Lock the numpy version to Major 1

### DIFF
--- a/agentuniverse/agent/action/knowledge/store/chroma_store.py
+++ b/agentuniverse/agent/action/knowledge/store/chroma_store.py
@@ -6,10 +6,11 @@
 # @Email   : wangchongshi.wcs@antgroup.com
 # @FileName: chroma_store.py
 from typing import List, Any, Optional
+from pydantic import SkipValidation
 
 import chromadb
 from chromadb import QueryResult
-from chromadb.api.models import Collection
+from chromadb.api.models.Collection import Collection
 
 from agentuniverse.agent.action.knowledge.store.document import Document
 from agentuniverse.agent.action.knowledge.store.query import Query
@@ -28,7 +29,7 @@ class ChromaStore(Store):
     """
 
     collection_name: Optional[str] = 'chroma_db'
-    collection: Collection = None
+    collection: SkipValidation[Collection] = None
     persist_path: Optional[str] = None
 
     def __init__(self, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dashscope = "^1.19.1"
 anthropic = "^0.26.0"
 ollama = '^0.2.1'
 langchain-anthropic = '^0.1.13'
+numpy = '^1.26.0'
 
 [tool.poetry.extras]
 log_ext = ["aliyun-log-python-sdk"]

--- a/sample_standard_app/config/gunicorn_config.toml
+++ b/sample_standard_app/config/gunicorn_config.toml
@@ -1,5 +1,5 @@
 [GUNICORN_CONFIG]
-bind = '127.0.0.1:8888'
+bind = '0.0.0.0:8888'
 backlog = 2048
 worker_class = 'gthread'
 threads = 4


### PR DESCRIPTION
Fix: Pydantic warning in chroma store
Fix: Lock the numpy version to Major 1, due to Major 2 cause some chromadb  bug
Change: Default gunicorn config bind address from 127.0.0.1 to 0.0.0.0